### PR TITLE
Build instructions: fix lcrypto googlecode.com dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,26 @@ or you can download [current sources as a zip file](https://github.com/kwart/tot
 
 ### How to build it
 
-You need to have [Maven](http://maven.apache.org/) installed
+Download `lcrypto-j2me-xxx.zip` ("xxx" - current version of lcrypto, for example "lcrypto-j2me-156.zip") 
+from the [Bouncy Castle website](https://www.bouncycastle.org/latest_releases.html) 
+and extract it to new `lcrypto-j2me` folder.
 
-	$ cd totp-me
+Copy folder `totp-me/for-lcrypto-j2me/` contents to `lcrypto-j2me` folder.
+
+Correct the lcrypto-j2me version number in `pom.xml` files
+* `lcrypto-j2me/pom.xml`: find `<version>1.56</version>`
+* `totp-me/pom.xml`: find `<artifactId>lcrypto-j2me</artifactId>` .. `<version>1.56</version>`
+
+Install [Maven](https://maven.apache.org).
+
+Build and install lcrypto-j2me
+
+	$ cd lcrypto-j2me
+	$ mvn clean install
+
+Build totp-me
+
+	$ cd ../totp-me
 	$ mvn clean package
 
 This default build uses Microemulator API implementation to simplify the build process, but it's only MIDP-2.0

--- a/for-lcrypto-j2me/pom.xml
+++ b/for-lcrypto-j2me/pom.xml
@@ -1,0 +1,85 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.bouncycastle</groupId>
+	<artifactId>lcrypto-j2me</artifactId>
+	<version>1.56</version>
+	<name>Bouncy Castle Lightweight API for J2ME</name>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<microemulator.version>2.0.4</microemulator.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.microemu</groupId>
+			<artifactId>microemulator</artifactId>
+			<version>${microemulator.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>[4.8.1,)</version>
+			<scope>test</scope><!-- see https://stackoverflow.com/a/12403544 --> 
+		</dependency>
+	</dependencies>
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/org/bouncycastle/math/ec/custom/sec/test</source>
+								<?ignoreme
+									<source>src/org/bouncycastle/util/test</source>
+									<source>src/org/bouncycastle/asn1/test</source>
+									<source>src/org/bouncycastle/openpgp/test</source>
+									<source>src/org/bouncycastle/crypto/prng/test</source>
+									<source>src/org/bouncycastle/crypto/ec/test</source>
+									<source>src/org/bouncycastle/crypto/test</source>
+									<source>src/org/bouncycastle/cert/test</source>
+									<source>src/org/bouncycastle/cms/test</source>
+									<source>src/java/math/test</source>
+								?>
+							</sources>
+						</configuration>
+						<!-- better solution: https://stackoverflow.com/a/35514742 --> 
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.3</source>
+					<target>1.1</target>
+					<compilerArguments>
+						<bootclasspath>${settings.localRepository}/org/microemu/cldcapi11/${microemulator.version}/cldcapi11-${microemulator.version}.jar${path.separator}${settings.localRepository}/org/microemu/midpapi20/${microemulator.version}/midpapi20-${microemulator.version}.jar</bootclasspath>
+					</compilerArguments>
+					<excludes>
+						<exclude>**/examples/*</exclude>
+						<exclude>**/test/*</exclude><!-- see https://stackoverflow.com/a/12403544 --> 
+						<exclude>**/org/bouncycastle/cert/dane/fetcher/*</exclude><!-- package javax.naming does not exist --> 
+					</excludes>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.microemu</groupId>
+						<artifactId>midpapi20</artifactId>
+						<version>${microemulator.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+</project>
+<!-- see also http://www.itcsolutions.eu/2010/09/03/how-to-use-bouncy-castle-lightweight-cryptographic-api-in-netbeans-for-j2me-midlets-projects/#comment-976 -->

--- a/for-lcrypto-j2me/pom.xml
+++ b/for-lcrypto-j2me/pom.xml
@@ -38,17 +38,6 @@
 						<configuration>
 							<sources>
 								<source>src/org/bouncycastle/math/ec/custom/sec/test</source>
-								<?ignoreme
-									<source>src/org/bouncycastle/util/test</source>
-									<source>src/org/bouncycastle/asn1/test</source>
-									<source>src/org/bouncycastle/openpgp/test</source>
-									<source>src/org/bouncycastle/crypto/prng/test</source>
-									<source>src/org/bouncycastle/crypto/ec/test</source>
-									<source>src/org/bouncycastle/crypto/test</source>
-									<source>src/org/bouncycastle/cert/test</source>
-									<source>src/org/bouncycastle/cms/test</source>
-									<source>src/java/math/test</source>
-								?>
 							</sources>
 						</configuration>
 						<!-- better solution: https://stackoverflow.com/a/35514742 --> 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>lcrypto-j2me</artifactId>
-			<version>1.45</version>
+			<version>1.56</version>
 		</dependency>
 
 		<dependency>
@@ -291,12 +291,5 @@
 			<url>sftp://web.sourceforge.net/home/project-web/totpme/htdocs</url>
 		</site>
 	</distributionManagement>
-
-	<repositories>
-		<repository>
-			<id>lcrypto</id>
-			<url>http://jinahya-files.googlecode.com/svn/maven/2/repo/</url>
-		</repository>
-	</repositories>
 
 </project>


### PR DESCRIPTION
Added steps to build and install lcrypto.

> ...since **googlecode.com** does not exist anymore and I couldn't find proper maven repository (pom.xml) for lcrypto-j2me.