### PR TITLE
Delta time: remove limits for old devices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<version.suffix>-SNAPSHOT</version.suffix>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<microemulator.version>2.0.3</microemulator.version>
+		<microemulator.version>2.0.4</microemulator.version>
 
 		<midlet.vendor>${project.organization.name}</midlet.vendor>
 		<midlet.name>${project.name}</midlet.name>


### PR DESCRIPTION
Some devices have timebomb.
i.e. device has hardcoded limits for the date range.

One of solutions: put device date (year) to the beginning of date range and set proper `delta` value.

Commits include:

- [x] Remove "Time correction is limited by one day" restriction
- [x] Change `delta` var type from `int` to `long`